### PR TITLE
stop having a default cache store

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,8 +10,6 @@ module RailsBase
   class Application < Rails::Application
     config.middleware.use Rack::Attack
 
-    config.cache_store = :redis_store, ENV['REDIS_URL']
-
     config.active_job.queue_adapter = :sidekiq
     config.active_job.queue_name_prefix = "rails5_#{Rails.env}"
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,6 +51,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_store, ENV.fetch('REDIS_URL')
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -51,6 +51,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_store, ENV.fetch('REDIS_URL')
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,4 @@
 Rails.application.configure do
-  config.cache_store = :null_store
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's


### PR DESCRIPTION
this caused the test env to look for Redis which caused me a lot of grief. This PR should also include 7fc6bc7b2df4607a81ab4b2c4e823f0997651c60 which I accidentally put into develop.